### PR TITLE
Provide metering labels for APICurito operator

### DIFF
--- a/apicurito/deploy/manifests/7.8.0/apicurito.crd.yaml
+++ b/apicurito/deploy/manifests/7.8.0/apicurito.crd.yaml
@@ -1,0 +1,38 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: apicuritos.apicur.io
+spec:
+  group: apicur.io
+  names:
+    kind: Apicurito
+    listKind: ApicuritoList
+    plural: apicuritos
+    singular: apicurito
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/apicurito/deploy/manifests/7.8.0/apicuritooperator.v7.8.0.clusterserviceversion.yaml
+++ b/apicurito/deploy/manifests/7.8.0/apicuritooperator.v7.8.0.clusterserviceversion.yaml
@@ -1,0 +1,234 @@
+# This is a generated file by tools/run/run.go
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [{
+              "apiVersion": "apicur.io/v1alpha1",
+              "kind": "Apicurito",
+              "metadata": {
+                "name": "apicurito-service"
+              },
+              "spec": {
+                "size": 3,
+                "image": "registry.redhat.io/fuse7/fuse-apicurito@sha256:1177f9ee841f95f40ea0b0de76f28c3a7b01ebef5ab335674f24bb5c17f88431"
+              }
+            }]
+    capabilities: Seamless Upgrades
+    categories: Integration & Delivery
+    certified: "false"
+    containerImage: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator:1.7
+    createdAt: "2020-09-17 16:58:03"
+    description: Manages the installation and upgrades of apicurito, a small/minimal
+      version of Apicurio
+    repository: https://github.com/Apicurio/apicurio-operators/tree/master/apicurito
+    support: Apicurito Project
+  name: apicuritooperator.v7.8.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: CRD for Apicurito
+      displayName: Apicurito CRD
+      kind: Apicurito
+      name: apicuritos.apicur.io
+      specDescriptors:
+      - description: The number of Apicurito pods to deploy
+        displayName: Size
+        path: size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Deployment
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: The image used for the Apicurito deployment
+        displayName: Image
+        path: image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Deployment
+        - urn:alm:descriptor:com.tectonic.ui:text
+      version: v1alpha1
+  description: |
+    Apicurito is a small/minimal version of Apicurio, a standalone API design studio that can be used to create new or edit existing API designs (using the OpenAPI specification).
+
+    This operator supports the installation and upgrade of apicurito. Apicurito components are:
+       - apicurito-ui (apicurito application)
+       - apicurito route (to access apicurito from outside openshift)
+
+    ### How to install
+    When the operator is installed (you have created a subscription and the operator is running in the selected namespace) create a new CR of Kind Apicurito (click the Create New button). The CR spec contains all defaults.
+
+    At the moment, following fields are supported as part of the CR:
+       - size: how many pods your the apicurito operand will have.
+       - image: the apicurito image, this can be found [here](https://hub.docker.com/r/apicurio/apicurito-ui/tags). Changing this image in an existing installation will trigger an upgrade of the operand.
+    ### How to upgrade
+    Upgrades are trigered by updating the image field in the CR. This can be done manually via the Openshift console, or with kubeclt:
+    ```
+    $ cat apicurito_cr.yaml
+        apiVersion: apicur.io/v1alpha1
+          kind: Apicurito
+          metadata:
+            name: apicurito-service
+          spec:
+            size: 3
+            image: apicurio/apicurito-ui:newversion
+     $ kubectl apply -f apicurito_cr.yaml
+    ```
+  displayName: Apicurito Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAYAAACtWK6eAAATSklEQVR4nOydXYgcV3bHzw1+UEDCCuRheljwGIyjBQeNKINkSOgy5EGGgEewsDIJeETyIJOAx5BgLRu45z5FIgSNiJd1HoJmyINlSNCYOOyYNXQNLOyYpPAI9mEMAc+Q0K1AwDPIsAMRnOWqz0hjqae6vm9V3fODQmPcVXW6q/99zrn33HOfIyIQBGEyv+XaAEFoMs+5NqBrKKVC/tP+OwMAZ/i/5wDghZSXOQCAL/jvPQDY4mOPiKIKzBaOQUmIlR+l1GkAuAgAFwBgHgDOA8CJim97KJ4dPu4Q0XbF9/QWEUhGlFILALDAHiKtR6iaXfYwkdZ6DRF3XBvUFUQgE4ii6Lkoil7i8GjOGHOePcRcDR6iDKxAtvv9/lYYhtbbWA+zg4gHrg1rGyKQI3DIZL3D+0dyhy5xAwCuE9Gea0PagoxiMUqpawDwDQDc7qg4gIX/jVLKhmFdfY/lYj2Ij4fW2ibXNwHglwDwa/tReHb8P7/3m1rrxcFgMOP6mTTx8CrE4hBqEQCWGpRgNwUbdt0CgGUJwZ7gjUCUUtZj3AGA513b0nD2AeAqEd1xbUgT6HwOopSaU0qtAMBdEUcq7Gf0kf3M7Gfn2hjXdNKDIOIJALhgjHkbAC63ZGi2KdwHgF9orWMeLl7zeXi4c6UmSimbY6DkGJlZtZ8bEckk4xE6JRAeqv1b13a0iF2blFsvIcKYTCcEwqNT1mu869qWlmAT8WtE9KFrQ5pOqwVic40oit7nYdvTru1pOFv9fv/TMAz/FQC2fc4rstBagXDR4IqMTE1FcosCtG6Y13oNpdSyDNtOxYZRl4hoUcRRANdT+RnLQ+YB4OcNKNNo8nFXa31Ra33C9fPqwuHcgJTCOMHhlOsvX5OPCADmXT+racd/Asy5tiHL0YqJQhm+TWQPAK4Q0ZprQ44Sj2fhQ15HM8+DKGf5f5uACB2bmIrGC0QpNc9VpzIbPpk3iGjdtRHx+DnN8xLkH6Y45UpAtFKDaYVorEAQMTTGvMsLmIQnPASAz7XWH3MZSK2Vt0PEGQB4FQCCkTFzRzxEVr4FgJ/0tF6eRbxfgaml0EiBIOKCMeauazsayntEtFznDYeIZ0bGXKtoHf6+/REMGtqtpZECUUp9mfNXqevUKo74SYOKH1Yd4va0PjeLuFXlPfLQmHkQnt9YUkqNRBzPsKK17lUpjgdR9NwQcX6IeDVW6m6s1K95runtOvK/kTEf2ftXfZ+sNMKDWHEYYzaPjHIIY2z4sUQVJ7M84mTv0a/yPilpVPLeCIFYz8Hrw4Un7NrwhogqCzvicRdI+9m/WdU9ctIYkTgPsbgS933XdjSMHZ70q1IcCACDBorDcrsp4ZZTgSDiAs9xzLi0o2GsDQaDN6ponDBEDGOlbsdKfQ0AuuzrlwnnJM5bEzkLsWQo9xkOAOCdKvKNhuUYWbA5WBhU6Emn4cyD8Hpx4Qn/WLY4hogn4nHDiq9bKA7gau1oiOhsrU/tAkHEGe4yIjPkY6znuDUYDP6mrAsOEWeGiFdHxnzJw7Rt5vmRMT91dfNaQyxOyLekocJj7gHAYpnJOE/udTF0vRUQLdV907oFErXU1VfBfQD4fpnJOA/b3u3w8uPah39rC7EQMRRxfIePSxbHMg/bdlUclmWuGq6NWgTCM+V/V8e9WkCpOcdXYfjn8bg8x4eOLjZp/9kQ8ZW6blhLiCWh1WOsOF4rI+eIx/ncSkMn+qpmLSC6VMeNKvcgXEYi4hizXpI45nmJrY/isFyMa+obXKlAcLy4RmqsGK21KXoNnl2OPC/sPOxRUDmVCiSKoh9Xef0WsaO1voQF1jsMEU8MERdGxvxM2h09oh8rtfYgiiotxa8sB+G15F9WcvF2scuFh7lHrKw4RrIcYCI9ra/MIlbmTaoUiCTmJSXlXHnb6OJCh6wHRG9UdfHSW4/ykG4bC+NKp9/vX4+iqEhYNcNrwf+iXMtq54AnRvf4AC7pf/z/e1o/07hhZMzMU6sZDxPz3wWAk1wF/kexUpeDinbEKt2DcFtQH8bkp3FPa30hb5PoIyNVbcs37Bd/g/+1v+6bVd5siDg3MmauqqYPpQoEEU8bY74p7YLt5lze0Io9x3ZLxLHDDbLte90KOtYHuOwQSyp0x7xXJO/gsKrJ4rjHw6yRy7UadVCqB1FKDbh3kq88BIC/ztt95KmcoylbU1hPttnT+gv+e2cWsVNeIonSHgLvDeizOCyfFxRHU8IqKwDDJR1e75le5kRhK5oRVwm3A83FyJjFBohj14aHPa3PBUQrvosDyvIgvELQ90VQURiGuYYa47H3dVF1sMfJtQ2hPplFrHTEqY0UFggiznVgWWdRdono9Twnxu6GxVcDokUH920VZYRYvucdwM3XMsOeo25xbADA6yKOdBQexVJK/RQArpZmUfvYIaIXs57ESfmoGpOOpTUb1zSFQiEWIp7wfe6j3+9/kOe8kTH/UL41z3AAAOs9rT+z//o0PFsWhQRijLnqe1fEMAz/Kes5XHz4g2osesx+T+uFWcRG7rvRFgqFWEqpHc9HrwxlDFniepYBPNobvWtlHy7I7UF4Ka3P4vhMa309ywncbGBQnUkQ9bS+MYvofM9CGL/fw6rb00e6rZxO2Xll56m/92Zr3m4O8noQbgDne1Hi72RdBBUr9REAXK7AlkcN6FzVRfH68MNdbc/wUdXirn0A2ORjq6f1ZpV7HOYVyCIA3K7EonawShmHSbkLyaiC3ZqiIOccTF54BO4i7wT25pF1Gq64d1hN3NN6rczBiLwCWfO4o4blRcoY38fVfGa7Pa0v1LFLLHdtPDzON3xb7nu8lmalqFfNnIMg4vc8F8d6FnHwevLrJX5mDwHg057Wqzx0m2tBVhK8eU04MuYFDpde5VV8beEsH+/GSt1nz3Ipz2eVJ0n/gxzndAat9SdZXs/l60mz5bscHqzxgqNnfvGGiKdHxhzuR75XRX/aI6X2Cx0bfJkBgIsjYy7nae6QRyC/l+OcLpG6oI/3tTiu2YL1AMtpQoBZxD2ezyh9ToMT7MOSly739Q3z9NLKXItljHG+LZZD9jP2tnq6yuCAhXEuIHI26gQcRsXjzjOH27F1WRyQt+IjT7Hiq3lu1BGuZXnxyJg/4z+tEG70tP59l8IYIl6IlboZKzUYGfMfnnWeeT7PxqCZQiw1dscvZb1JR7hHRB+mfTFX6r7ClbNOyz14BAo9E8Qk5vnHKjVZPYjPpe1Z41f7hXzHpTiGiHMcRg1EHI/IPPiQVSC+riH4VmudWiD2F7un9UJVzczS8iCK5qVd6RN4JDATqScKPS8vWacK21tWCc/g+94N/pCdIOPanSwepNatrxrGtmsD8sKNF0KeXfadzEszsgjE2/xDa/2VaxuKwCJZ5GFmnzmRdY/DLAK5mN2ezvAL1wYUJSDaOtnv176NcgO5kOXFWXKQ+vaLbhb7RNSZSbRYtqXYCIhSR0OpPIgaj6P7ypprA0pmgddU+Eqm0vy0IZbPCXqtG9dXjc1Helpf9DgfeWE47uWWilQhlsfrP3aJyPVioEqIlbrrcUea1NUNaT1IZ2LwjHS2tX9P6w3XNjik3BzE4xCryy1zuvzeSmOqQKLxNruuu447QWvdtQT9MafC8FcA8IVrOxxRngeJosjXxnD3sMOdCE+F4UMAyNS2qEOkzivL3B+ka3Q2/zgkIFrzdMg3dVVvGoF8r5gtrcWXGN1pxbErhuO+0lNJI5Cm7JVXN50Nr57CS4GMjElVciIhltD5ULIIIpBjIMfLZOtC9iFMRnIQATwe7p2K5CACeFyXNRUJsSbjS4IuTEEEIggJiEAEIQERiCAkIAKZTOX7bQjtQAQyGRnVER4hAhGEBEQggpCACEQQEhCBCEICIhBBSEAEMhnfurj42pRjKiKQybyEKVectR3efcrLphxpEIFM5qQx5rJrI2pCGlonIAI5ns53HeTNdXzsmJkaEcjxvMmblnaZzv8IFEUEkswdROxkwv5g3O/spms7mo4IJJnzxphl10ZUwYMouuzhaF1mRCDTeRsRO9ddcmSM5B4pEIGkIIqiH7u2oUxipdDnPSezIAJJwcbGxl92ZZetWCkbMmrXdrQFEUh61lTGHVKbxhDR2v+uazvahAgkPc8DwEqbZ9hHxog4MiICycZZY8w/t00kQ8QZDq3+1LUtbUMEkp0fGGM22xJuxUotjozZ5tBKmgBmRASSj7MAEDU9cR8iWvtuSzFifkQg+bFfugGOv4SNI1bq9MiY267taDsikIIYY/5NKXUbERd4P0enWK/BWzyPsm6aLzyLxKTFOQkAi8YYe2wBwBUiqn3PjVipBS5d79d97y4jHqRcbOL+pVJqSym1VEeJSqzUUqzUDgDcFXGUjwikGmwSf9MY899Kqa+VUr9USg2UUjYcw6x5yxDxlVipmzZ0ipUaxEp9GSs1ipUirshNvSmlkA0JsarlOc4DjuYCf2yM0QBwCRGn7sPOi5p+DgCdK5hsA+JBHGGMeTvlS1dEHO4QgbhjapgVjycjpSzdISIQd5xWSk3biliWxDpGBOIW5/MmQjIiELdMmy+RvRIdIwJxxzpN2aO8p/UdAPikPpOEpxGBuGFfa/3etBfNIh4ERDYP2azHLOFpRCD1cgAAqwAwj4jbaU/qaf2WeBI3iECqY5/FcAkAXgeAF4not4lokYgy5RaziDvWkwREqqd1j69nPdAtyVOqRWbSy2On3+9/GobhvwPANiJW8sWdRbxvDwCIYNzf6q8eRNFLAHBmZMx5Hho+U8W9fUQEUhz7ZX2LiCIXNz8Vhg9PhaEN17Znx6UrP4qVWgIAlIVSxZEQqxg22b7kShzHERAtc/1X6jxHmIwIJB9bNgfQWs8hYiNHmAKivZcHgz8EgBuy73t+JMTKziYRvebaiDScCsP/C4iuxUpd55zlrGub2oZ4kIxord9xbUNWgvGEZCieJDsikGysImLty2nLgEVyw7UdbUMEko4DXmu+6NqQIrw8GHzAcydCSkQg6bhDRCuujSjKqTB8GBAtAYBxbUtbEIGkQGv9sWsbyiQgQgBILJQUxohAprN/OGvdMaauhxdEINOwucdlRDxwbUjZ9LRedW1DGxCBJHODiNZdG1EFs4jWK95zbUfTEYEk0/rEfApdf3+FEYEcz2rWsvS20dP6QymXT0YEcjyd3P75KLPj3EpykQREIMfgogG1I7o4QlcaIpDJ+BR2+PJDkAsRyGS8KerjGq2vXNvRVEQgk+ncvMcUvPlByIoIZDLyhREeIQKZjG8eRDgGEYggJCACEYQERCCCkIAIRBASEIEIQgIiEEFIQAQiCAmIQAQhARGIICQgAhGEBEQggpCACEQQEhCBCEICIhBBSEAEIggJiEAEIQERiCAkkEYgPnX48BXpbHIM4kEm49vWAL69X0j7oyAeZAJaa9++MN55EG53NJU0AvGxgcH/ujagZnz7EUzd1X6qQBDxvocf4P+4NqBOgnGb1W9d21Ejqdutps1BPslvSyv5lWsDHODTe0697YMioukvUmoBAO4Wtaol7BPRaddG1E2s1EcAcNm1HTWwH2R4vqk8CBGtAcB2IbPaw4euDXDByX5/07UNNZHp+WYZ5vVlE/rrrg1wwakw3HBtQw0cZH2+qQXC+4Tv5zKrPaxSyuG/DrLtwfPdTju8e0jWicKu72nX9fd3LLzbVNe3hs4835NJIFpr7HDn800i8nq3pZ7WS12eNMyz9XWqUazvnKDUTQBYynqjpqO1voKI3nqQQ2Kl5gDga9d2VMBGQBRmPSlzLZbW+rOs57QEr73HIcF4Z98ujmhhnpMyCyQMw887tjOqjb2t9/CtWuBYTvb7f+/ahhKxz/etIGf4nDnEenyiUjahezPXyc3iEs/zCEeIO/R8gwLPt4hATnNC90LemzeAVSJadG1EE4m78Xy3AqJzRS6Qez0IzxcstLja934XBxvKInjyfNtM4VSg0IIpItrq9/vXihrhgIN+v/+Ox5OCqQiItnpa21/g/3JtS0bsj/atlweDD4peKHeI9Z2LKLUCAG8XvlA97ANASOMSbyEFQ8SFkTFtKVa14ngtKOn5liIQGIsEAUCXcrHqEHHkJFZqGQDedW1HCm4FRKWFzqWtSScibHipwoGIIz/8pbvi2o4p7Pa0LrXYtNSmDYPB4ApX/TatHGVTa/26iKMYAdFKT+vvA8C6a1ueYrOn9Ts9rc/MjlfAlkZpIdYzF25GyLXH8xwyS14ycTOeL5QdUj1NZW1/OOT6UVXXT8kVEUc1BOPne85xv4JbPa0rHUWtzIMcgohnAOCiMeZPAODVSm82Du3WtdYbNh9CRBnGrZgHUTTzIIouj4zp2xwPAKperrx1st//l1Nh+JPZGp5v5QL5zs2Ush/gIk9APV/ipXcBYEVrvSyicEus1BIXBpb5fO0zvWWfMRdT1katAnl803EZw1U+ipQy3AOAZV7tKDQELlMJuVKhX+BS9vlGPa2vl518p8WJQL5jwHj9wQIf9oM9m/DyDV4aese6WpkJbz68vsSKxf57EQDOJ7x8g73Fln3GAZHzRiHOBSIITUaaVwtCAr8JAAD//8HkCbs9orrZAAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consolelinks
+          - consoleyamlsamples
+          verbs:
+          - get
+          - create
+          - list
+          - update
+          - delete
+        serviceAccountName: apicurito
+      deployments:
+      - name: apicurito-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: apicurito
+              name: apicurito-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app: apicurito
+                com.company: Red_Hat
+                name: apicurito-operator
+                rht.comp: Fuse
+                rht.comp_ver: "7.8"
+                rht.prod_name: Red_Hat_Integration
+                rht.prod_ver: "7.8"
+                rht.subcomp: apicurito-operator
+                rht.subcomp_t: infrastructure
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: RELATED_IMAGE_APICURITO_OPERATOR
+                  value: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator:1.7
+                - name: RELATED_IMAGE_APICURITO
+                  value: apicurio/apicurito-ui:1.1.1
+                - name: RELATED_IMAGE_GENERATOR
+                  value: apicurio/fuse-apicurito-generator:latest
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: apicurito-operator
+                image: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator:1.7
+                imagePullPolicy: Always
+                name: apicurito-operator
+                resources: {}
+              serviceAccountName: apicurito
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - apicurito
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - apicur.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - watch
+        serviceAccountName: apicurito
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - api
+  - apicurio
+  - apicurito
+  labels:
+    name: apicuritooperator
+  links:
+  - name: Apicurito source code
+    url: https://github.com/Apicurio/apicurito
+  - name: Apicurito operator source code
+    url: https://github.com/Apicurio/apicurio-operators/tree/master/apicurito
+  maintainers:
+  - email: apicurio@lists.jboss.org
+    name: Apicurito Project
+  maturity: alpha
+  provider:
+    name: Red Hat
+  relatedImages:
+  - image: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator:1.7
+    name: fuse-apicurito-operator
+  - image: registry.redhat.io/fuse7/fuse-apicurito:1.7
+    name: fuse-apicurito
+  replaces: apicuritooperator.v0.2.0
+  selector:
+    matchLabels:
+      name: apicuritooperator
+  version: 7.8.0

--- a/apicurito/deploy/manifests/apicurito.package.yaml
+++ b/apicurito/deploy/manifests/apicurito.package.yaml
@@ -1,8 +1,8 @@
-#! package-manifest: deploy/manifests/0.2.0/apicuritooperator.v0.2.0.clusterserviceversion.yaml
+#! package-manifest: deploy/manifests/7.8.0/apicuritooperator.v7.8.0.clusterserviceversion.yaml
 channels:
-- currentCSV: apicuritooperator.v0.1.0
-  name: alpha
 - currentCSV: apicuritooperator.v0.2.0
+  name: alpha
+- currentCSV: apicuritooperator.v7.8.0
   name: alpha-offline
 defaultChannel: alpha
 packageName: apicurito

--- a/apicurito/deploy/operator.yaml
+++ b/apicurito/deploy/operator.yaml
@@ -1,3 +1,4 @@
+# This is a generated file by tools/run/run.go
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13,7 +14,14 @@ spec:
     metadata:
       labels:
         app: apicurito
+        com.company: Red_Hat
         name: apicurito-operator
+        rht.comp: Fuse
+        rht.comp_ver: "7.8"
+        rht.prod_name: Red_Hat_Integration
+        rht.prod_ver: "7.8"
+        rht.subcomp: apicurito-operator
+        rht.subcomp_t: infrastructure
     spec:
       containers:
       - env:
@@ -26,7 +34,7 @@ spec:
         - name: RELATED_IMAGE_APICURITO
           value: apicurio/apicurito-ui:1.1.1
         - name: RELATED_IMAGE_GENERATOR
-          value: fuse-apicurito-generator:latest
+          value: apicurio/fuse-apicurito-generator:latest
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/apicurito/deploy/role.yaml
+++ b/apicurito/deploy/role.yaml
@@ -1,3 +1,4 @@
+# This is a generated file by tools/run/run.go
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/apicurito/pkg/resources/deplomentconfig.go
+++ b/apicurito/pkg/resources/deplomentconfig.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1"
 	"github.com/apicurio/apicurio-operators/apicurito/pkg/configuration"
+	"github.com/apicurio/apicurio-operators/apicurito/version"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +36,16 @@ import (
 func apicuritoDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep resource.KubernetesResource) {
 	// Define a new deployment
 	var dm int32 = 420
+	deployLabels := map[string]string{
+		"app":           "apicurito",
+		"com.company":   "Red_Hat",
+		"rht.prod_name": "Red_Hat_Integration",
+		"rht.prod_ver":  version.ShortVersion(),
+		"rht.comp":      "Fuse",
+		"rht.comp_ver":  version.ShortVersion(),
+		"rht.subcomp":   fmt.Sprintf("%s-%s", a.Name, "ui"),
+		"rht.subcomp_t": "infrastructure",
+	}
 	dep = &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -54,14 +65,14 @@ func apicuritoDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &a.Spec.Size,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: deployLabels,
 			},
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RollingUpdateDeploymentStrategyType,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels: deployLabels,
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
@@ -122,6 +133,16 @@ func apicuritoDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 // Creates and returns a generator Deployment object
 func generatorDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep resource.KubernetesResource) {
 	// Define a new deployment
+	deployLabels := map[string]string{
+		"app":           "apicurito",
+		"com.company":   "Red_Hat",
+		"rht.prod_name": "Red_Hat_Integration",
+		"rht.prod_ver":  version.ShortVersion(),
+		"rht.comp":      "Fuse",
+		"rht.comp_ver":  version.ShortVersion(),
+		"rht.subcomp":   fmt.Sprintf("%s-%s", a.Name, "generator"),
+		"rht.subcomp_t": "infrastructure",
+	}
 	dep = &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -142,14 +163,14 @@ func generatorDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &a.Spec.Size,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: deployLabels,
 			},
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RollingUpdateDeploymentStrategyType,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels: deployLabels,
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{

--- a/apicurito/scripts/go-build.sh
+++ b/apicurito/scripts/go-build.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 REGISTRY=quay.io/${USER}
 IMAGE=apicurito-operator
-TAG=v0.2
+TAG=$(grep Version version/version.go | head -1|awk -F '=' '{print $2}'|sed 's/\ *"//g')
+if [[ -z ${TAG} ]]; then
+  echo "ERROR: No Version found in version/version.go. "$(grep Version version/version.go|head -1) 
+  exit 1
+fi
 
 export GO111MODULE=on
+
 go mod vendor
 
 go generate ./...

--- a/apicurito/tools/components/components.go
+++ b/apicurito/tools/components/components.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/apicurio/apicurio-operators/apicurito/pkg/configuration"
+	"github.com/apicurio/apicurio-operators/apicurito/version"
 
 	monv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	consolev1 "github.com/openshift/api/console/v1"
@@ -35,8 +36,15 @@ func GetDeployment(operatorName, repository, context, imageName, tag, imagePullP
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"name": operatorName,
-						"app":  "apicurito",
+						"name":          operatorName,
+						"app":           "apicurito",
+						"com.company":   "Red_Hat",
+						"rht.prod_name": "Red_Hat_Integration",
+						"rht.prod_ver":  version.ShortVersion(),
+						"rht.comp":      "Fuse",
+						"rht.comp_ver":  version.ShortVersion(),
+						"rht.subcomp":   operatorName,
+						"rht.subcomp_t": "infrastructure",
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/apicurito/version/version.go
+++ b/apicurito/version/version.go
@@ -1,7 +1,17 @@
 package version
 
-var (
-	Version = "0.2.0"
-
-	PriorVersion = "0.1.0"
+import (
+	"strings"
 )
+
+var (
+	// this version drives the container image tag in scripts/go-build.sh
+	Version      = "7.8.0"
+	PriorVersion = "0.2.0"
+)
+
+// Return the major.minor, as 7.8, instead of 7.8.0
+func ShortVersion() string {
+	idx := strings.LastIndex(Version, ".")
+	return Version[:idx]
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/ENTESB-14399

* The image version when building the image is driven by `apicurito/version/version.go`.
* Create parent version directory in manifest directory when generating the csv
* Added a comment in each generated yaml file.