### PR TITLE
Align service labels and route endpoint with documentation

### DIFF
--- a/apicurito/pkg/controller/apicurito/apicurito_controller.go
+++ b/apicurito/pkg/controller/apicurito/apicurito_controller.go
@@ -165,7 +165,7 @@ func (r *ReconcileApicurito) Reconcile(request reconcile.Request) (reconcile.Res
 	// This is needed because ConfigMaps require the routes to be present and should run only once
 	// at startup
 	route := &routev1.Route{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("%s-%s", apicurito.Name, "generator"), Namespace: apicurito.Namespace}, route)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: fmt.Sprintf("%s-service-generator", apicurito.Name), Namespace: apicurito.Namespace}, route)
 	if err != nil && errors.IsNotFound(err) {
 		routes := rs.Routes()
 		err = r.applyResources(apicurito, routes, reqLogger)

--- a/apicurito/pkg/resources/configmap.go
+++ b/apicurito/pkg/resources/configmap.go
@@ -43,7 +43,7 @@ func apicuritoConfig(client client.Client, a *v1alpha1.Apicurito) (c resource.Ku
 	// Fetch the route host from generator
 	r := &routev1.Route{}
 	if err = client.Get(context.TODO(), types.NamespacedName{
-		Name:      fmt.Sprintf("%s-%s", a.Name, "generator"),
+		Name:      fmt.Sprintf("%s-service-generator", a.Name),
 		Namespace: a.Namespace}, r); err != nil {
 		return c, err
 	}
@@ -58,7 +58,7 @@ func apicuritoConfig(client client.Client, a *v1alpha1.Apicurito) (c resource.Ku
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", a.Name, "ui"),
+			Name:      fmt.Sprintf("%s-ui", a.Name),
 			Namespace: a.Namespace,
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{

--- a/apicurito/pkg/resources/deplomentconfig.go
+++ b/apicurito/pkg/resources/deplomentconfig.go
@@ -44,7 +44,7 @@ func apicuritoDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 		"rht.prod_ver":  version.ShortVersion(),
 		"rht.comp":      "Fuse",
 		"rht.comp_ver":  version.ShortVersion(),
-		"rht.subcomp":   fmt.Sprintf("%s-%s", a.Name, "ui"),
+		"rht.subcomp":   fmt.Sprintf("%s-service-ui", a.Name),
 		"rht.subcomp_t": "infrastructure",
 	}
 	dep = &appsv1.Deployment{
@@ -53,7 +53,7 @@ func apicuritoDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", a.Name, "ui"),
+			Name:      fmt.Sprintf("%s-service-ui", a.Name),
 			Namespace: a.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(a, schema.GroupVersionKind{
@@ -79,7 +79,7 @@ func apicuritoDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 					Containers: []corev1.Container{{
 						Image:           c.UiImage,
 						ImagePullPolicy: corev1.PullIfNotPresent,
-						Name:            fmt.Sprintf("%s-%s", a.Name, "ui"),
+						Name:            fmt.Sprintf("%s-service-ui", a.Name),
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8080,
 							Name:          "api-port",
@@ -142,7 +142,7 @@ func generatorDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 		"rht.prod_ver":  version.ShortVersion(),
 		"rht.comp":      "Fuse",
 		"rht.comp_ver":  version.ShortVersion(),
-		"rht.subcomp":   fmt.Sprintf("%s-%s", a.Name, "generator"),
+		"rht.subcomp":   fmt.Sprintf("%s-service-generator", a.Name),
 		"rht.subcomp_t": "infrastructure",
 	}
 	dep = &appsv1.Deployment{
@@ -151,7 +151,7 @@ func generatorDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", a.Name, "generator"),
+			Name:      fmt.Sprintf("%s-service-generator", a.Name),
 			Namespace: a.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(a, schema.GroupVersionKind{
@@ -178,7 +178,7 @@ func generatorDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 					Containers: []corev1.Container{{
 						Image:           c.GeneratorImage,
 						ImagePullPolicy: corev1.PullIfNotPresent,
-						Name:            fmt.Sprintf("%s-%s", a.Name, "generator"),
+						Name:            fmt.Sprintf("%s-service-generator", a.Name),
 						Ports: []corev1.ContainerPort{
 							{
 								ContainerPort: 8080,

--- a/apicurito/pkg/resources/route.go
+++ b/apicurito/pkg/resources/route.go
@@ -28,14 +28,13 @@ import (
 )
 
 func generatorRoute(a *v1alpha1.Apicurito) (r resource.KubernetesResource) {
-
 	r = &routev1.Route{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Route",
 			APIVersion: routev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GetGeneratorRouteName(a),
+			Name:      fmt.Sprintf("%s-service-generator", a.Name),
 			Namespace: a.Namespace,
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{
@@ -61,14 +60,13 @@ func generatorRoute(a *v1alpha1.Apicurito) (r resource.KubernetesResource) {
 }
 
 func apicuritoRoute(a *v1alpha1.Apicurito) (r resource.KubernetesResource) {
-
 	r = &routev1.Route{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Route",
 			APIVersion: routev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GetUIRouteName(a),
+			Name:      fmt.Sprintf("%s-service-ui", a.Name),
 			Namespace: a.Namespace,
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{
@@ -93,9 +91,9 @@ func apicuritoRoute(a *v1alpha1.Apicurito) (r resource.KubernetesResource) {
 }
 
 func GetGeneratorRouteName(a *v1alpha1.Apicurito) string {
-	return fmt.Sprintf("%s-%s", a.Name, "generator")
+	return fmt.Sprintf("%s-service-generator", a.Name)
 }
 
 func GetUIRouteName(a *v1alpha1.Apicurito) string {
-	return fmt.Sprintf("%s-%s", a.Name, "ui")
+	return fmt.Sprintf("%s-service-ui", a.Name)
 }

--- a/apicurito/pkg/resources/service.go
+++ b/apicurito/pkg/resources/service.go
@@ -35,14 +35,14 @@ var labels = map[string]string{"app": "apicurito"}
 func apicuritoService(a *v1alpha1.Apicurito) (s resource.KubernetesResource) {
 
 	// Define new service
-	labels["component"] = fmt.Sprintf("%s-%s", a.Name, "ui")
+	labels["component"] = fmt.Sprintf("%s-ui", a.Name)
 	s = &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", a.Name, "ui"),
+			Name:      fmt.Sprintf("%s-service-ui", a.Name),
 			Namespace: a.Namespace,
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{
@@ -78,7 +78,7 @@ func generatorService(a *v1alpha1.Apicurito) (s resource.KubernetesResource) {
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", a.Name, "generator"),
+			Name:      fmt.Sprintf("%s-service-generator", a.Name),
 			Namespace: a.Namespace,
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{


### PR DESCRIPTION
Basically add the word `service` to the services labels, names and routes name