### PR TITLE
ENTESB-15995 : permission problem on creation of metrics service

### DIFF
--- a/apicurito/Dockerfile
+++ b/apicurito/Dockerfile
@@ -1,0 +1,1 @@
+build/Dockerfile

--- a/apicurito/deploy/cluster_role.yaml
+++ b/apicurito/deploy/cluster_role.yaml
@@ -14,3 +14,9 @@ rules:
   - list
   - update
   - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update

--- a/apicurito/kustomize/bases/deployment/Makefile
+++ b/apicurito/kustomize/bases/deployment/Makefile
@@ -9,6 +9,7 @@ DEPLOYMENT := ./deployment.gen
 SA := ./service_account.gen
 
 # User customisable variables
+SYNC ?= true
 IMAGE ?= registry.redhat.io/fuse7/fuse-apicurito-rhel7-operator
 NAMESPACE ?= apicurito
 TAG ?= 1.9
@@ -20,10 +21,12 @@ TAG ?= 1.9
 # Copy the deploy template from the deploy directory
 #
 sync:
+ifeq ($(SYNC), true)
 	cp $(ASSETS)/operator.yaml $(DEPLOYMENT).$(TMPL)
-	sed -i '/ RELATED_IMAGE_APICURITO_OPERATOR/,/RELATED_IMAGE_APICURITO/s~value: .*~value: $(IMAGE_VAR):$(TAG_VAR)~' $(DEPLOYMENT).$(TMPL)
+	sed -i '/ RELATED_IMAGE_APICURITO_OPERATOR/,/ name:/s~value: .*~value: $(IMAGE_VAR):$(TAG_VAR)~' $(DEPLOYMENT).$(TMPL)
 	sed -i 's~image: .*~image: $(IMAGE_VAR):$(TAG_VAR)~' $(DEPLOYMENT).$(TMPL)
 	cp $(ASSETS)/service_account.yaml $(SA).$(TMPL)
+endif
 # end-sync
 
 init: sync


### PR DESCRIPTION
* Occurs when installing as user rather than admin

* cluster_role
 * Adds the finalizers permission to the cluster role so the service account
   is granted it correctly

* Adds Dockerfile symlink

* Adds SYNC variable to kustomize installer to allow for syncing to be
  skipped if installing from the source. This allows for the deployment
  template file to be modified prior to install, eg. changing env vars.