### PR TITLE
ENTESB-15994 Apicurito upgrade errors from 7.8 to 7.9 due to metering labels

### DIFF
--- a/apicurito/pkg/resources/deplomentconfig.go
+++ b/apicurito/pkg/resources/deplomentconfig.go
@@ -36,15 +36,16 @@ import (
 func apicuritoDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep resource.KubernetesResource) {
 	// Define a new deployment
 	var dm int32 = 420
+	name := fmt.Sprintf("%s-%s", a.Name, "ui")
 	deployLabels := map[string]string{
 		"app":           "apicurito",
-		"component":     fmt.Sprintf("%s-%s", a.Name, "ui"),
+		"component":     name,
 		"com.company":   "Red_Hat",
 		"rht.prod_name": "Red_Hat_Integration",
 		"rht.prod_ver":  version.ShortVersion(),
 		"rht.comp":      "Fuse",
 		"rht.comp_ver":  version.ShortVersion(),
-		"rht.subcomp":   fmt.Sprintf("%s-%s", a.Name, "ui"),
+		"rht.subcomp":   name,
 		"rht.subcomp_t": "infrastructure",
 	}
 	dep = &appsv1.Deployment{
@@ -53,7 +54,7 @@ func apicuritoDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", a.Name, "ui"),
+			Name:      name,
 			Namespace: a.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(a, schema.GroupVersionKind{
@@ -66,7 +67,7 @@ func apicuritoDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &a.Spec.Size,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: labelComponent(name),
 			},
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RollingUpdateDeploymentStrategyType,
@@ -79,7 +80,7 @@ func apicuritoDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 					Containers: []corev1.Container{{
 						Image:           c.UiImage,
 						ImagePullPolicy: corev1.PullIfNotPresent,
-						Name:            fmt.Sprintf("%s-%s", a.Name, "ui"),
+						Name:            name,
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 8080,
 							Name:          "api-port",
@@ -105,18 +106,18 @@ func apicuritoDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 						},
 						VolumeMounts: []corev1.VolumeMount{
 							{
-								Name:      fmt.Sprintf("%s-%s", a.Name, "ui"),
+								Name:      name,
 								MountPath: "/html/config",
 							},
 						},
 					}},
 					Volumes: []corev1.Volume{
 						{
-							Name: fmt.Sprintf("%s-%s", a.Name, "ui"),
+							Name: name,
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: fmt.Sprintf("%s-%s", a.Name, "ui"),
+										Name: name,
 									},
 									DefaultMode: &dm,
 								},
@@ -134,15 +135,16 @@ func apicuritoDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 // Creates and returns a generator Deployment object
 func generatorDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep resource.KubernetesResource) {
 	// Define a new deployment
+	name := fmt.Sprintf("%s-%s", a.Name, "generator")
 	deployLabels := map[string]string{
 		"app":           "apicurito",
-		"component":     fmt.Sprintf("%s-%s", a.Name, "ui"),
+		"component":     name,
 		"com.company":   "Red_Hat",
 		"rht.prod_name": "Red_Hat_Integration",
 		"rht.prod_ver":  version.ShortVersion(),
 		"rht.comp":      "Fuse",
 		"rht.comp_ver":  version.ShortVersion(),
-		"rht.subcomp":   fmt.Sprintf("%s-%s", a.Name, "generator"),
+		"rht.subcomp":   name,
 		"rht.subcomp_t": "infrastructure",
 	}
 	dep = &appsv1.Deployment{
@@ -151,7 +153,7 @@ func generatorDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", a.Name, "generator"),
+			Name:      name,
 			Namespace: a.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(a, schema.GroupVersionKind{
@@ -165,7 +167,7 @@ func generatorDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &a.Spec.Size,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: labelComponent(name),
 			},
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RollingUpdateDeploymentStrategyType,
@@ -178,7 +180,7 @@ func generatorDeployment(c *configuration.Config, a *v1alpha1.Apicurito) (dep re
 					Containers: []corev1.Container{{
 						Image:           c.GeneratorImage,
 						ImagePullPolicy: corev1.PullIfNotPresent,
-						Name:            fmt.Sprintf("%s-%s", a.Name, "generator"),
+						Name:            name,
 						Ports: []corev1.ContainerPort{
 							{
 								ContainerPort: 8080,

--- a/apicurito/pkg/resources/service.go
+++ b/apicurito/pkg/resources/service.go
@@ -35,16 +35,16 @@ var labels = map[string]string{"app": "apicurito"}
 func apicuritoService(a *v1alpha1.Apicurito) (s resource.KubernetesResource) {
 
 	// Define new service
-	labels["component"] = fmt.Sprintf("%s-%s", a.Name, "ui")
+	name := fmt.Sprintf("%s-%s", a.Name, "ui")
 	s = &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", a.Name, "ui"),
+			Name:      name,
 			Namespace: a.Namespace,
-			Labels:    labels,
+			Labels:    labelComponent(name),
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(a, schema.GroupVersionKind{
 					Group:   v1alpha1.SchemeGroupVersion.Group,
@@ -55,7 +55,7 @@ func apicuritoService(a *v1alpha1.Apicurito) (s resource.KubernetesResource) {
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeClusterIP,
-			Selector: labels,
+			Selector: labelComponent(name),
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "api-port",
@@ -70,8 +70,6 @@ func apicuritoService(a *v1alpha1.Apicurito) (s resource.KubernetesResource) {
 }
 
 func generatorService(a *v1alpha1.Apicurito) (s resource.KubernetesResource) {
-	labels["component"] = "apicurito-generator"
-
 	s = &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -80,7 +78,7 @@ func generatorService(a *v1alpha1.Apicurito) (s resource.KubernetesResource) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%s", a.Name, "generator"),
 			Namespace: a.Namespace,
-			Labels:    labels,
+			Labels:    labelComponent("apicurito-generator"),
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(a, schema.GroupVersionKind{
 					Group:   v1alpha1.SchemeGroupVersion.Group,
@@ -91,7 +89,7 @@ func generatorService(a *v1alpha1.Apicurito) (s resource.KubernetesResource) {
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeClusterIP,
-			Selector: labels,
+			Selector: labelComponent("apicurito-generator"),
 			Ports: []corev1.ServicePort{
 				{
 					Name:       "http",
@@ -103,4 +101,13 @@ func generatorService(a *v1alpha1.Apicurito) (s resource.KubernetesResource) {
 	}
 
 	return
+}
+
+func labelComponent(name string) map[string]string {
+	_labels := make(map[string]string)
+	for index, element := range labels {
+		_labels[index] = element
+	}
+	_labels["component"] = name
+	return _labels
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/ENTESB-15994

Fixed a bug which the labels map were modified in services.go and later invocations had the "component" value overwritten.