### PR TITLE
Show head commit id on operator log

### DIFF
--- a/apicurito/pkg/cmd/run.go
+++ b/apicurito/pkg/cmd/run.go
@@ -87,6 +87,8 @@ var (
 
 var log = logf.Log.WithName("cmd")
 
+var GitCommit string
+
 func init() {
 	// Register custom metrics with the global prometheus registry
 	customMetrics.Registry.MustRegister(operatorVersion)
@@ -97,6 +99,7 @@ func printVersion() {
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
 	log.Info(fmt.Sprintf("Version of apicurito operator: %v", version.Version))
+	log.Info(fmt.Sprintf("Apicurito-operator Git Commit: %v", GitCommit))
 }
 
 func (o *options) run() error {

--- a/apicurito/scripts/go-build.sh
+++ b/apicurito/scripts/go-build.sh
@@ -2,16 +2,17 @@
 REGISTRY=quay.io/${USER}
 IMAGE=apicurito-operator
 TAG=v1.1.0
-
+GIT_COMMIT=$(git rev-list -1 HEAD)
 export GO111MODULE=on
-go mod vendor
+GOFLAGS="-X github.com/apicurio/apicurio-operators/apicurito/pkg/cmd.GitCommit=${GIT_COMMIT}"
 
+go mod vendor
 go generate ./...
 
 ./scripts/go-test.sh
 
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-  go build -v -a \
+  go build -ldflags "${GOFLAGS}" \
   -o build/_output/bin/apicurito \
   -mod=vendor github.com/apicurio/apicurio-operators/apicurito/cmd/manager
 


### PR DESCRIPTION
Print the commit id on operator log to help debug issues in operator
builds and runtime execution.
Also disable verbose go compile