### PR TITLE
ENTESB-16969: Fixes permission in operator log

### DIFF
--- a/apicurito/config/rbac/role.yaml
+++ b/apicurito/config/rbac/role.yaml
@@ -43,6 +43,17 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - ""
+  resources:
+  - services
+  - services/finalizers
+  verbs:
+  - list
+  - get
+  - watch
+  - create
+  - update
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors


### PR DESCRIPTION
Error message:
Could not create ServiceMonitor object",
"error":"servicemonitors.monitoring.coreos.com \"fuse-apicurito-metrics\"
 is forbidden: cannot set blockOwnerDeletion if an ownerReference refers
to a resource you can't set finalizers on

* Provides the operator service account with the permission to update
  finalizers for services